### PR TITLE
Missing enclosure added

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -18,6 +18,7 @@ layout: null
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
         <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
         <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
+        <enclosure url="http://download.phptownhall.com/{{ post.filename }}.mp3" type="audio/mp3" length="{{ post.bytes }}" />
         {% for tag in post.tags %}
         <category>{{ tag | xml_escape }}</category>
         {% endfor %}


### PR DESCRIPTION
I was wondering why I could add this podd to my podcast-app (gpodder), but no episodes would show up. 
The enclosure is missing.
After six years, am I the first to detect this? Or does everyone else use iTunes?